### PR TITLE
Refine .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # dependencies
 node_modules/
 


### PR DESCRIPTION
## Description

At https://github.com/takanome-dev/assign-issue-action/pull/261/files, I saw a macOS binary file be added. This should not happen.

## Related Tickets & Documents

One could have a `.gitingore` be genereated at https://www.toptal.com/developers/gitignore?templates=macos.

