### PR TITLE
feat: add block assignment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,12 @@ inputs:
       👋 Hey @{{ handle }}, it looks like you're interested in working on this issue! 🎉
 
       If you'd like to take on this issue, please use the command `{{{ trigger }}}` to assign yourself.
+  block_assignment:
+    description: Whether to block self-assignment after unassignment
+    default: 'true'
+  block_assignment_comment:
+    description: Message shown when blocked from self-assignment
+    default: 'You cannot assign yourself to this issue again. Please ask a maintainer to do it.'
 
 outputs:
   assigned:

--- a/src/utils/lib/inputs.ts
+++ b/src/utils/lib/inputs.ts
@@ -19,4 +19,5 @@ export enum INPUTS {
   UNASSIGNED_COMMENT = 'unassigned_comment',
   ALREADY_ASSIGNED_COMMENT = 'already_assigned_comment',
   ASSIGNMENT_SUGGESTION_COMMENT = 'assignment_suggestion_comment',
+  BLOCK_ASSIGNMENT_COMMENT = 'block_assignment_comment',
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 💡 Feature


## Description

This PR adds the ability to block users from self-assigning to an issue after they've been unassigned, requiring maintainer intervention.
## Features

- Added `block_assignment` input (default: true) to control whether users can self-assign after being unassigned
- Added `block_assignment_comment` input to customize the blocking message


## Related Tickets & Documents

fixes #293 


## [optional] What gif best describes this PR or how it makes you feel?
