### PR TITLE
Fix self assign bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,42 +61,80 @@ inputs:
     description: >
       The comment posted after a user has assigned themselves to an issue.
     default: |
-      👋 Hey @{{ handle }}, thanks for your interest in this issue! 🎉
+      ### 🎉 Issue Assignment Confirmation
 
-      > [!NOTE]
-      > ⏳ Please note, you will be automatically unassigned if the issue isn't closed within **{{ total_days }} days** (by **{{ unassigned_date }}**).
-      > A maintainer can also add the "**{{{ pin_label }}}**"" label to prevent automatic unassignment.
+      Hey @{{ handle }}, thanks for taking on this issue!
+
+      > [!IMPORTANT]
+      > This issue will be automatically unassigned if not closed within **{{ total_days }} days** (by **{{ unassigned_date }})**.
+
+      <details>
+      <summary>ℹ️ Important information</summary>
+
+      - To prevent automatic unassignment, a maintainer can add the **{{{ pin_label }}}** label
+      - You can unassign yourself at any time by commenting with `/unassign-me`
+      - Updates and status reports are encouraged to show progress
+      </details>
   already_assigned_comment:
     description: >
       The comment posted when a user tries to assign themselves to an issue that is already assigned.
     default: |
-      👋 Hey @{{ handle }}, this issue is already assigned to @{{ assignee }}.
+      ### ⚠️ Issue Already Assigned
+
+      Hi @{{ handle }}, this issue is currently assigned to @{{ assignee }}.
 
       > [!NOTE]
-      > ⏳ If the issue isn't closed within **{{ total_days }} days**, it will be automatically unassigned.
-      > A maintainer can also add you to the list of assignees or swap you with the current assignee.
+      > If no progress is made within **{{ total_days }} days**, the issue will be automatically unassigned.
+
+      <details>
+      <summary>Options for contributors</summary>
+
+      - **Wait for availability**: The issue may become available if auto-unassigned
+      - **Collaborate**: You can ask @{{ assignee }} if they want help
+      - **Maintainer assistance**: A maintainer can add you as co-assignee if appropriate
+      </details>
   unassigned_comment:
     description: >
       The comment posted after a user is unassigned from an issue.
     default: |
-      👋 Hey @{{ handle }}, you've been automatically unassigned from this issue due to inactivity.
+      ### 📋 Assignment Update
 
-      > [!NOTE]
-      > If you'd like to be re-assigned, just leave another comment or ask a maintainer to assign you again.
-      > If you're still actively working on the issue, let us know by commenting, and we can pin it to prevent automatic unassignment.
+      Hi @{{ handle }}, you are no longer assigned to this issue.
+
+      <details open>
+      <summary>Next steps</summary>
+
+      **If you still want to work on this:**
+      - Comment with `/assign-me` to request reassignment
+      - Ask a maintainer to assign you again
+      - If you're making progress, a maintainer can add the pin label to prevent future automatic unassignment
+      </details>
   assignment_suggestion_comment:
     description: >
       The comment posted when someone shows interest in being assigned to an issue without using the assignment commands.
     default: |
-      👋 Hey @{{ handle }}, it looks like you're interested in working on this issue! 🎉
+      ### 👋 Interested in Contributing?
 
-      If you'd like to take on this issue, please use the command `{{{ trigger }}}` to assign yourself.
+      Hi @{{ handle }}, it looks like you're interested in working on this issue!
+
+      > [!TIP]
+      > Use the command `{{{ trigger }}}` to assign yourself to this issue.
+
+      Once assigned, you can start working on it right away. We appreciate your contribution!
   block_assignment:
     description: Whether to block self-assignment after unassignment
     default: 'true'
   block_assignment_comment:
     description: Message shown when blocked from self-assignment
-    default: 'You cannot assign yourself to this issue again. Please ask a maintainer to do it.'
+    default: |
+      ### ⚠️ Reassignment Blocked
+
+      Hi @{{ handle }}, you cannot assign yourself to this issue again.
+
+      > [!NOTE]
+      > Since you were previously unassigned from this issue, a maintainer needs to approve your reassignment.
+
+      Please ask a maintainer to assign you if you'd like to continue working on this issue.
 
 outputs:
   assigned:

--- a/dist/index.js
+++ b/dist/index.js
@@ -38839,7 +38839,7 @@ var CommentHandler = class {
     });
   }
   handle_issue_comment() {
-    var _a, _b, _c, _d, _e, _f, _g, _h;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
     core.info(
       `\u{1F916} Checking commands in the issue (#${(_a = this.issue) == null ? void 0 : _a.number}) comments"`
     );
@@ -38883,26 +38883,24 @@ var CommentHandler = class {
     if (body === selfUnassignCmd || body.includes(selfUnassignCmd)) {
       return this.$_handle_self_unassignment();
     }
-    if (maintainers.length > 0) {
-      if (maintainers.includes((_g = (_f = this.comment) == null ? void 0 : _f.user) == null ? void 0 : _g.login)) {
-        if (body.startsWith(assignCommenterCmd)) {
-          return this.$_handle_user_assignment(assignCommenterCmd);
-        }
-        if (body.startsWith(unassignCommenterCmd)) {
-          return this.$_handle_user_unassignment(unassignCommenterCmd);
-        }
-      } else {
+    if (body.includes(assignCommenterCmd) || body.includes(unassignCommenterCmd)) {
+      if (!maintainersInput) {
         return core.info(
-          `\u{1F916} Ignoring comment because the commenter is not in the list of maintainers specified in the config file`
+          `\u{1F916} Ignoring maintainer command because the "maintainers" input is empty`
         );
       }
-    } else {
-      return core.info(
-        `\u{1F916} Ignoring comment because the "maintainers" input in the config file is empty`
-      );
+      if (!maintainers.includes((_g = (_f = this.comment) == null ? void 0 : _f.user) == null ? void 0 : _g.login)) {
+        return core.info(
+          `\u{1F916} Ignoring maintainer command because user @${(_i = (_h = this.comment) == null ? void 0 : _h.user) == null ? void 0 : _i.login} is not in the maintainers list`
+        );
+      }
+      if (body.includes(assignCommenterCmd)) {
+        return this.$_handle_user_assignment(assignCommenterCmd);
+      }
+      return this.$_handle_user_unassignment(unassignCommenterCmd);
     }
     return core.info(
-      `\u{1F916} Ignoring comment: ${(_h = this.context.payload.comment) == null ? void 0 : _h.id} because it does not contain a supported command.`
+      `\u{1F916} Ignoring comment: ${(_j = this.context.payload.comment) == null ? void 0 : _j.id} because it does not contain a supported command.`
     );
   }
   $_handle_assignment_interest() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38904,14 +38904,31 @@ var CommentHandler = class {
     );
   }
   $_handle_assignment_interest() {
-    var _a, _b;
-    return this._create_comment(
-      "assignment_suggestion_comment" /* ASSIGNMENT_SUGGESTION_COMMENT */,
-      {
-        handle: (_b = (_a = this.comment) == null ? void 0 : _a.user) == null ? void 0 : _b.login,
-        trigger: core.getInput("self_assign_cmd" /* SELF_ASSIGN_CMD */)
+    return __async(this, null, function* () {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l;
+      const daysUntilUnassign = Number(core.getInput("days_until_unassign" /* DAYS_UNTIL_UNASSIGN */));
+      if (((_a = this.issue) == null ? void 0 : _a.assignee) || (((_c = (_b = this.issue) == null ? void 0 : _b.assignees) == null ? void 0 : _c.length) || 0) > 0) {
+        yield this._create_comment(
+          "already_assigned_comment" /* ALREADY_ASSIGNED_COMMENT */,
+          {
+            unassigned_date: String(daysUntilUnassign),
+            handle: (_e = (_d = this.comment) == null ? void 0 : _d.user) == null ? void 0 : _e.login,
+            assignee: (_g = (_f = this.issue) == null ? void 0 : _f.assignee) == null ? void 0 : _g.login
+          }
+        );
+        core.setOutput("assigned", "no");
+        return core.info(
+          `\u{1F916} Issue #${(_h = this.issue) == null ? void 0 : _h.number} is already assigned to @${(_j = (_i = this.issue) == null ? void 0 : _i.assignee) == null ? void 0 : _j.login}`
+        );
       }
-    );
+      return this._create_comment(
+        "assignment_suggestion_comment" /* ASSIGNMENT_SUGGESTION_COMMENT */,
+        {
+          handle: (_l = (_k = this.comment) == null ? void 0 : _k.user) == null ? void 0 : _l.login,
+          trigger: core.getInput("self_assign_cmd" /* SELF_ASSIGN_CMD */)
+        }
+      );
+    });
   }
   $_handle_self_assignment() {
     return __async(this, null, function* () {
@@ -39217,6 +39234,7 @@ var CommentHandler = class {
       "Assign me",
       "Assign me this issue",
       "Assign this for me",
+      "Please assign",
       "Can I take on this issue",
       "Can I take up this issue",
       "May I work on this issue",

--- a/src/handlers/comment-handler.ts
+++ b/src/handlers/comment-handler.ts
@@ -143,7 +143,24 @@ export default class CommentHandler {
     );
   }
 
-  private $_handle_assignment_interest() {
+  private async $_handle_assignment_interest() {
+    const daysUntilUnassign = Number(core.getInput(INPUTS.DAYS_UNTIL_UNASSIGN));
+
+    if (this.issue?.assignee || (this.issue?.assignees?.length || 0) > 0) {
+      await this._create_comment<AlreadyAssignedCommentArg>(
+        INPUTS.ALREADY_ASSIGNED_COMMENT,
+        {
+          unassigned_date: String(daysUntilUnassign),
+          handle: this.comment?.user?.login,
+          assignee: this.issue?.assignee?.login,
+        },
+      );
+      core.setOutput('assigned', 'no');
+      return core.info(
+        `🤖 Issue #${this.issue?.number} is already assigned to @${this.issue?.assignee?.login}`,
+      );
+    }
+
     return this._create_comment<AssignmentInterestCommentArg>(
       INPUTS.ASSIGNMENT_SUGGESTION_COMMENT,
       {
@@ -485,6 +502,7 @@ export default class CommentHandler {
       'Assign me',
       'Assign me this issue',
       'Assign this for me',
+      'Please assign',
       'Can I take on this issue',
       'Can I take up this issue',
       'May I work on this issue',

--- a/src/handlers/comment-handler.ts
+++ b/src/handlers/comment-handler.ts
@@ -94,6 +94,7 @@ export default class CommentHandler {
 
     const body = (this.context.payload.comment?.body as string).toLowerCase();
 
+    // Handle auto-suggestion first
     if (
       enableAutoSuggestion &&
       this._contribution_phrases().some((phrase) =>
@@ -104,6 +105,7 @@ export default class CommentHandler {
       return this.$_handle_assignment_interest();
     }
 
+    // Handle self-assignment commands (available to all users)
     if (body === selfAssignCmd || body.includes(selfAssignCmd)) {
       return this.$_handle_self_assignment();
     }
@@ -112,24 +114,28 @@ export default class CommentHandler {
       return this.$_handle_self_unassignment();
     }
 
-    if (maintainers.length > 0) {
-      if (maintainers.includes(this.comment?.user?.login)) {
-        if (body.startsWith(assignCommenterCmd)) {
-          return this.$_handle_user_assignment(assignCommenterCmd);
-        }
-
-        if (body.startsWith(unassignCommenterCmd)) {
-          return this.$_handle_user_unassignment(unassignCommenterCmd);
-        }
-      } else {
+    // Handle maintainer-only commands
+    if (
+      body.includes(assignCommenterCmd) ||
+      body.includes(unassignCommenterCmd)
+    ) {
+      if (!maintainersInput) {
         return core.info(
-          `🤖 Ignoring comment because the commenter is not in the list of maintainers specified in the config file`,
+          `🤖 Ignoring maintainer command because the "maintainers" input is empty`,
         );
       }
-    } else {
-      return core.info(
-        `🤖 Ignoring comment because the "maintainers" input in the config file is empty`,
-      );
+
+      if (!maintainers.includes(this.comment?.user?.login)) {
+        return core.info(
+          `🤖 Ignoring maintainer command because user @${this.comment?.user?.login} is not in the maintainers list`,
+        );
+      }
+
+      if (body.includes(assignCommenterCmd)) {
+        return this.$_handle_user_assignment(assignCommenterCmd);
+      }
+
+      return this.$_handle_user_unassignment(unassignCommenterCmd);
     }
 
     return core.info(


### PR DESCRIPTION
This PR fixes a critical bug where self-assignment commands (`/assign-me`, `/unassign-me`) were being incorrectly blocked by the maintainers check.

## Bug Description

The action was incorrectly checking maintainer permissions for all commands, including self-assignment commands that should be available to all contributors.

## Testing

The fix should allow:
- Any contributor to use `/assign-me` and `/unassign-me`
- Only maintainers to use `/assign @user` and `/unassign @user`
- Proper error messages for each case

## Tickets

- [x] fixes #287
- [x] fixes #296
- [x] fixes #299 
- [x] fixes #290
